### PR TITLE
Allow RSS Feed Title to be customized

### DIFF
--- a/packages/gatsby-theme-egghead-blog/gatsby-config.js
+++ b/packages/gatsby-theme-egghead-blog/gatsby-config.js
@@ -4,7 +4,7 @@ require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
 })
 
-module.exports = ({ contentBlog = 'content/blog' }) => ({
+module.exports = ({ contentBlog = 'content/blog', rssFeedTitle = 'Blog RSS Feed' }) => ({
   plugins: [
     {
       resolve: `gatsby-plugin-page-creator`,
@@ -89,7 +89,7 @@ module.exports = ({ contentBlog = 'content/blog' }) => ({
               }
             `,
             output: '/rss.xml',
-            title: 'Blog RSS Feed',
+            title: rssFeedTitle,
           },
         ],
       },


### PR DESCRIPTION
Thanks for the excellent conversion from a starter to a theme! If it's alright I'd love to be able to adjust the title for the RSS feed, but it seemed excessive to overwrite the entire plugin just to do that. It was also tempting to use the `siteMetadata.title`, but I personally wanted to have a different title for RSS feeds.